### PR TITLE
[Issue #2] Add Dimension constraints with relative relations

### DIFF
--- a/SketchKit.podspec
+++ b/SketchKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SketchKit'
-  s.version          = '1.2.0'
+  s.version          = '1.3.0'
   s.summary          = 'A lightweight autolayout DSL library for iOS.'
   s.homepage         = 'https://github.com/dogo/SketchKit'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/SketchKit/Extensions/UIView+Anchors.swift
+++ b/Sources/SketchKit/Extensions/UIView+Anchors.swift
@@ -225,6 +225,20 @@ public extension UIView {
     }
 
     @discardableResult
+    func heightAnchor(lessThanOrEqualTo layoutDimension: NSLayoutDimension, multiplier: CGFloat = 1.0) -> Self {
+        let constraint = heightAnchor.constraint(lessThanOrEqualTo: layoutDimension, multiplier: multiplier)
+        constraint.isActive = true
+        return self
+    }
+
+    @discardableResult
+    func heightAnchor(greaterThanOrEqual layoutDimension: NSLayoutDimension, multiplier: CGFloat = 1.0) -> Self {
+        let constraint = heightAnchor.constraint(greaterThanOrEqualTo: layoutDimension, multiplier: multiplier)
+        constraint.isActive = true
+        return self
+    }
+
+    @discardableResult
     func widthAnchor(equalTo width: CGFloat,
                      priority: UILayoutPriority = UILayoutPriority.required) -> Self {
         let constraint = widthAnchor.constraint(equalToConstant: width)
@@ -254,6 +268,20 @@ public extension UIView {
     @discardableResult
     func widthAnchor(equalTo layoutDimension: NSLayoutDimension, multiplier: CGFloat = 1.0) -> Self {
         let constraint = widthAnchor.constraint(equalTo: layoutDimension, multiplier: multiplier)
+        constraint.isActive = true
+        return self
+    }
+
+    @discardableResult
+    func widthAnchor(lessThanOrEqualTo layoutDimension: NSLayoutDimension, multiplier: CGFloat = 1.0) -> Self {
+        let constraint = widthAnchor.constraint(lessThanOrEqualTo: layoutDimension, multiplier: multiplier)
+        constraint.isActive = true
+        return self
+    }
+
+    @discardableResult
+    func widthAnchor(greaterThanOrEqual layoutDimension: NSLayoutDimension, multiplier: CGFloat = 1.0) -> Self {
+        let constraint = widthAnchor.constraint(greaterThanOrEqualTo: layoutDimension, multiplier: multiplier)
         constraint.isActive = true
         return self
     }

--- a/Tests/SketchKitTests/UIView/HeightAnchorTests.swift
+++ b/Tests/SketchKitTests/UIView/HeightAnchorTests.swift
@@ -64,9 +64,9 @@ final class HeightAnchorTests: XCTestCase {
         XCTAssertEqual(constraints[0].relation, NSLayoutConstraint.Relation.equal, "Should be equal")
     }
 
-    // MARK: - HeightAnchor greaterThanOrEqualTo
+    // MARK: - HeightAnchor greaterThanOrEqualToConstant
 
-    func testHeightAnchorGreaterThanOrEqualTo() {
+    func testHeightAnchorGreaterThanOrEqualToConstant() {
 
         let view = UIView()
         self.container.addSubview(view)
@@ -84,9 +84,9 @@ final class HeightAnchorTests: XCTestCase {
         XCTAssertEqual(constraints[0].relation, NSLayoutConstraint.Relation.greaterThanOrEqual, "Should be greaterThanOrEqual")
     }
 
-    // MARK: - HeightAnchor lessThanOrEqualTo
+    // MARK: - HeightAnchor lessThanOrEqualToConstant
 
-    func testHeightAnchorLessThanOrEqual() {
+    func testHeightAnchorLessThanOrEqualToConstant() {
 
         let view = UIView()
         self.container.addSubview(view)
@@ -104,10 +104,62 @@ final class HeightAnchorTests: XCTestCase {
         XCTAssertEqual(constraints[0].relation, NSLayoutConstraint.Relation.lessThanOrEqual, "Should be lessThanOrEqual")
     }
 
+    // MARK: - HeightAnchor greaterThanOrEqualTo
+
+    func testHeightAnchorGreaterThanOrEqualTo() {
+
+        let viewOne = UIView()
+        let viewTwo = UIView()
+        self.container.addSubview(viewOne)
+        self.container.addSubview(viewTwo)
+
+        viewTwo.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+
+        viewOne.layout.applyConstraint { view in
+            view.heightAnchor(greaterThanOrEqual: viewTwo.heightAnchor)
+            view.heightAnchor(equalTo: 10)
+        }
+
+        viewOne.layoutIfNeeded()
+
+        let constraints = viewOne.constraints
+
+        XCTAssertEqual(constraints.count, 1, "Should have 1 constraint installed")
+        XCTAssertEqual(constraints[0].constant, 10, "Constant should be 10")
+        XCTAssertEqual(viewOne.frame.height, 20, "Should be 20")
+    }
+
+    // MARK: - HeightAnchor lessThanOrEqualTo
+
+    func testHeightAnchorLessThanOrEqualTo() {
+
+        let viewOne = UIView()
+        let viewTwo = UIView()
+        self.container.addSubview(viewOne)
+        self.container.addSubview(viewTwo)
+
+        viewTwo.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+
+        viewOne.layout.applyConstraint { view in
+            view.heightAnchor(lessThanOrEqualTo: viewTwo.heightAnchor)
+            view.heightAnchor(equalTo: 30)
+        }
+
+        viewOne.layoutIfNeeded()
+
+        let constraints = viewOne.constraints
+
+        XCTAssertEqual(constraints.count, 1, "Should have 1 constraint installed")
+        XCTAssertEqual(constraints[0].constant, 30, "Constant should be 30")
+        XCTAssertEqual(viewOne.frame.height, 20, "Should be 20")
+    }
+
     static var allTests = [
         ("testHeightAnchor", testHeightAnchor),
         ("testSafeHeightAnchor", testSafeHeightAnchor),
+        ("testHeightAnchorGreaterThanOrEqualToConstant", testHeightAnchorGreaterThanOrEqualToConstant),
+        ("testHeightAnchorLessThanOrEqualToConstant", testHeightAnchorLessThanOrEqualToConstant),
         ("testHeightAnchorGreaterThanOrEqualTo", testHeightAnchorGreaterThanOrEqualTo),
-        ("testHeightAnchorLessThanOrEqual", testHeightAnchorLessThanOrEqual)
+        ("testHeightAnchorLessThanOrEqualTo", testHeightAnchorLessThanOrEqualTo)
     ]
 }

--- a/Tests/SketchKitTests/UIView/WidthAnchorTests.swift
+++ b/Tests/SketchKitTests/UIView/WidthAnchorTests.swift
@@ -66,7 +66,7 @@ final class WidthAnchorTests: XCTestCase {
 
     // MARK: - WidthAnchor greaterThanOrEqual
 
-    func testWidthAnchorGreaterThanOrEqual() {
+    func testWidthAnchorGreaterThanOrEqualToConstant() {
 
         let view = UIView()
         self.container.addSubview(view)
@@ -84,9 +84,9 @@ final class WidthAnchorTests: XCTestCase {
         XCTAssertEqual(constraints[0].relation, NSLayoutConstraint.Relation.greaterThanOrEqual, "Should be greaterThanOrEqual")
     }
 
-    // MARK: - WidthAnchor greaterThanOrEqual
+    // MARK: - WidthAnchor lessThanOrEqualToConstant
 
-    func testWidthAnchorLessThanOrEqualTo() {
+    func testWidthAnchorLessThanOrEqualToConstant() {
 
         let view = UIView()
         self.container.addSubview(view)
@@ -104,10 +104,62 @@ final class WidthAnchorTests: XCTestCase {
         XCTAssertEqual(constraints[0].relation, NSLayoutConstraint.Relation.lessThanOrEqual, "Should be lessThanOrEqual")
     }
 
+    // MARK: - WidthAnchor greaterThanOrEqualTo
+
+    func testWidthAnchorGreaterThanOrEqualTo() {
+
+        let viewOne = UIView()
+        let viewTwo = UIView()
+        self.container.addSubview(viewOne)
+        self.container.addSubview(viewTwo)
+
+        viewTwo.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+
+        viewOne.layout.applyConstraint { view in
+            view.widthAnchor(greaterThanOrEqual: viewTwo.widthAnchor)
+            view.widthAnchor(equalTo: 10)
+        }
+
+        viewOne.layoutIfNeeded()
+
+        let constraints = viewOne.constraints
+
+        XCTAssertEqual(constraints.count, 1, "Should have 1 constraint installed")
+        XCTAssertEqual(constraints[0].constant, 10, "Constant should be 10")
+        XCTAssertEqual(viewOne.frame.width, 20, "Should be 20")
+    }
+
+    // MARK: - WidthAnchor lessThanOrEqualTo
+
+    func testWidthAnchorLessThanOrEqualTo() {
+
+        let viewOne = UIView()
+        let viewTwo = UIView()
+        self.container.addSubview(viewOne)
+        self.container.addSubview(viewTwo)
+
+        viewTwo.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+
+        viewOne.layout.applyConstraint { view in
+            view.widthAnchor(lessThanOrEqualTo: viewTwo.widthAnchor)
+            view.widthAnchor(equalTo: 30)
+        }
+
+        viewOne.layoutIfNeeded()
+
+        let constraints = viewOne.constraints
+
+        XCTAssertEqual(constraints.count, 1, "Should have 1 constraint installed")
+        XCTAssertEqual(constraints[0].constant, 30, "Constant should be 30")
+        XCTAssertEqual(viewOne.frame.width, 20, "Should be 20")
+    }
+
     static var allTests = [
         ("testWidthAnchor", testWidthAnchor),
         ("testSafeWidthAnchor", testSafeWidthAnchor),
-        ("testWidthAnchorGreaterThanOrEqual", testWidthAnchorGreaterThanOrEqual),
+        ("testWidthAnchorGreaterThanOrEqual", testWidthAnchorGreaterThanOrEqualToConstant),
+        ("testWidthAnchorLessThanOrEqualTo", testWidthAnchorLessThanOrEqualToConstant),
+        ("testWidthAnchorGreaterThanOrEqualTo", testWidthAnchorGreaterThanOrEqualTo),
         ("testWidthAnchorLessThanOrEqualTo", testWidthAnchorLessThanOrEqualTo)
     ]
 }


### PR DESCRIPTION
###### Fixes issue #2 
As I stated in issue #2, I've added helper functions to NSLayoutAnchor's interface to allow constraining of dimension properties related to other view's dimensions.
I have not added these functions to the UILayoutGuide extension since I don't think these would be needed. Thoughts?

###### This PR changes:
 - Add heightAnchor(greaterThanOrEqual:, multiplier:)
 - Add heightAnchor(lessThanOrEqual:, multiplier:)
 - Add widthAnchor(greaterThanOrEqual:, multiplier:)
 - Add widthAnchor(lessThanOrEqual:, multiplier:)