### PR TITLE
Fix keyboard layout guide notifications and update Codecov action

### DIFF
--- a/.github/workflows/Testing.yml
+++ b/.github/workflows/Testing.yml
@@ -63,7 +63,7 @@ jobs:
             test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/Sources/SketchKit/KeyboardLayoutGuide.swift
+++ b/Sources/SketchKit/KeyboardLayoutGuide.swift
@@ -133,7 +133,10 @@ extension Notification {
         } else {
             if let view {
                 let keyboardFrameInView = convertedKeyboardFrame(keyboardFrame.cgRectValue, to: view)
-                return max(0.0, view.bounds.intersection(keyboardFrameInView).height)
+                // Distance from the view's bottom up to the keyboard's top, so the guide pushes
+                // content above the keyboard even when the keyboard is floating/undocked.
+                let distanceFromBottom = view.bounds.maxY - keyboardFrameInView.minY
+                return max(0.0, min(distanceFromBottom, view.bounds.height))
             }
 
             return max(0.0, UIScreen.main.bounds.height - keyboardFrame.cgRectValue.minY)

--- a/Sources/SketchKit/KeyboardLayoutGuide.swift
+++ b/Sources/SketchKit/KeyboardLayoutGuide.swift
@@ -22,8 +22,10 @@ final class SKKeyboard {
 final class KeyboardLayoutGuide: LayoutGuide {
 
     private var bottomConstraint: NSLayoutConstraint?
+    private let notificationCenter: NotificationCenter
 
     init(notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.notificationCenter = notificationCenter
         super.init()
 
         // Observe keyboardWillChangeFrame notifications
@@ -49,7 +51,7 @@ final class KeyboardLayoutGuide: LayoutGuide {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        notificationCenter.removeObserver(self)
     }
 
     /// Sets up the layout guide's initial constraints.
@@ -71,20 +73,20 @@ final class KeyboardLayoutGuide: LayoutGuide {
     /// Adjusts the layout guide's height based on the keyboard's frame.
     @objc
     private func adjustKeyboard(_ notification: Notification) {
-        if var height = notification.keyboardHeight, let duration = notification.animationDuration {
+        if var height = notification.keyboardHeight(in: owningView), let duration = notification.animationDuration {
             if #available(iOS 11.0, *), height > 0, let bottom = owningView?.safeAreaInsets.bottom {
                 height -= bottom
             }
             heightConstraint?.constant = height
             if duration > 0.0 {
-                animate(notification)
+                animate()
             }
             SKKeyboard.shared.currentHeight = height
         }
     }
 
     /// Animates the layout changes when the keyboard frame changes.
-    private func animate(_ notification: Notification) {
+    private func animate() {
         if let owningView = owningView, isVisible(view: owningView) {
             owningView.layoutIfNeeded()
         } else {
@@ -122,6 +124,11 @@ extension LayoutGuide {
 extension Notification {
     /// Retrieves the keyboard's height from the notification's userInfo.
     var keyboardHeight: CGFloat? {
+        return keyboardHeight(in: nil)
+    }
+
+    /// Retrieves the keyboard's height from the notification's userInfo, converted to a specific view when possible.
+    func keyboardHeight(in view: UIView?) -> CGFloat? {
         guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
             return nil
         }
@@ -129,10 +136,22 @@ extension Notification {
         if name == UIResponder.keyboardWillHideNotification {
             return 0.0
         } else {
-            // Keyboard frame behaves differently across iOS versions, so we calculate based on screen height.
-            let screenHeight = UIApplication.shared.keyWindow?.bounds.height ?? UIScreen.main.bounds.height
-            return screenHeight - keyboardFrame.cgRectValue.minY
+            if let view {
+                let keyboardFrameInView = convertedKeyboardFrame(keyboardFrame.cgRectValue, to: view)
+                return max(0.0, view.bounds.intersection(keyboardFrameInView).height)
+            }
+
+            return max(0.0, UIScreen.main.bounds.height - keyboardFrame.cgRectValue.minY)
         }
+    }
+
+    private func convertedKeyboardFrame(_ keyboardFrame: CGRect, to view: UIView) -> CGRect {
+        guard let window = view.window else {
+            return view.convert(keyboardFrame, from: nil)
+        }
+
+        let keyboardFrameInWindow = window.convert(keyboardFrame, from: nil)
+        return view.convert(keyboardFrameInWindow, from: window)
     }
 
     /// Retrieves the keyboard's animation duration from the notification's userInfo.

--- a/Sources/SketchKit/KeyboardLayoutGuide.swift
+++ b/Sources/SketchKit/KeyboardLayoutGuide.swift
@@ -122,11 +122,6 @@ extension LayoutGuide {
 }
 
 extension Notification {
-    /// Retrieves the keyboard's height from the notification's userInfo.
-    var keyboardHeight: CGFloat? {
-        return keyboardHeight(in: nil)
-    }
-
     /// Retrieves the keyboard's height from the notification's userInfo, converted to a specific view when possible.
     func keyboardHeight(in view: UIView?) -> CGFloat? {
         guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {

--- a/Tests/SketchKitTests/KeyboardLayoutGuideTests.swift
+++ b/Tests/SketchKitTests/KeyboardLayoutGuideTests.swift
@@ -160,6 +160,33 @@ final class KeyboardLayoutGuideTests: XCTestCase {
         )
     }
 
+    func testAdjustKeyboard_FloatingKeyboard_ComputesHeightFromKeyboardTop() {
+        sut.setUp()
+
+        let screenHeight = UIScreen.main.bounds.height
+        // Floating keyboard: its top is 400pt from the bottom of the view, and it does not
+        // extend down to the view's bottom edge.
+        let floatingKeyboardTop = screenHeight - 400
+        let keyboardFrame = CGRect(x: 50, y: floatingKeyboardTop, width: 320, height: 290)
+        let notification = Notification(name: UIResponder.keyboardWillChangeFrameNotification, object: nil, userInfo: [
+            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: keyboardFrame),
+            UIResponder.keyboardAnimationDurationUserInfoKey: CGFloat(0.25)
+        ])
+
+        NotificationCenter.default.post(notification)
+
+        XCTAssertEqual(
+            SKKeyboard.shared.currentHeight,
+            400,
+            "Height should be the distance from the view's bottom to the keyboard's top, not the intersection height"
+        )
+        XCTAssertEqual(
+            sut.heightConstraint?.constant,
+            400,
+            "The height constraint should lift content above the floating keyboard"
+        )
+    }
+
     func testAdjustKeyboardWhenKeyboardWillHide() {
         sut.setUp()
 

--- a/Tests/SketchKitTests/KeyboardLayoutGuideTests.swift
+++ b/Tests/SketchKitTests/KeyboardLayoutGuideTests.swift
@@ -17,7 +17,7 @@ final class KeyboardLayoutGuideTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockView = UIView()
+        mockView = UIView(frame: UIScreen.main.bounds)
         sut = KeyboardLayoutGuide()
 
         mockView.addLayoutGuide(sut)
@@ -35,7 +35,11 @@ final class KeyboardLayoutGuideTests: XCTestCase {
 
         let heightConstraint = sut.heightConstraint
         XCTAssertNotNil(heightConstraint, "Height constraint should be applied")
-        XCTAssertEqual(heightConstraint?.constant, 0, "Height constraint should match the SKKeyboard.shared.currentHeight")
+        XCTAssertEqual(
+            heightConstraint?.constant,
+            0,
+            "Height constraint should match the SKKeyboard.shared.currentHeight"
+        )
 
         XCTAssertTrue(mockView.constraints.contains {
             $0.firstAnchor == sut.leftAnchor && $0.secondAnchor == mockView.leftAnchor
@@ -46,8 +50,57 @@ final class KeyboardLayoutGuideTests: XCTestCase {
         }, "Right constraint should be applied between the layout guide and the owning view")
 
         XCTAssertNotNil(sut.bottomConstraint, "Bottom constraint should be updated")
-        XCTAssertEqual(sut.bottomConstraint?.firstAnchor, sut.bottomAnchor, "Bottom constraint should anchor to the layout guide's bottomAnchor")
-        XCTAssertEqual(sut.bottomConstraint?.secondAnchor, mockView.safeBottomAnchor, "Bottom constraint should anchor to the view's safeBottomAnchor")
+        XCTAssertEqual(
+            sut.bottomConstraint?.firstAnchor,
+            sut.bottomAnchor,
+            "Bottom constraint should anchor to the layout guide's bottomAnchor"
+        )
+        XCTAssertEqual(
+            sut.bottomConstraint?.secondAnchor,
+            mockView.safeBottomAnchor,
+            "Bottom constraint should anchor to the view's safeBottomAnchor"
+        )
+    }
+
+    func testKeyboardLayout_CreatesAndConfiguresGuide() {
+        let view = UIView(frame: UIScreen.main.bounds)
+
+        let keyboardLayout = view.keyboardLayout
+
+        XCTAssertTrue(
+            keyboardLayout is KeyboardLayoutGuide,
+            "The public keyboardLayout getter should create a KeyboardLayoutGuide"
+        )
+        XCTAssertEqual(
+            keyboardLayout.identifier,
+            "KeyboardLayoutGuide",
+            "The layout guide should be identifiable for later reuse"
+        )
+        XCTAssertTrue(
+            view.layoutGuides.contains { $0 === keyboardLayout },
+            "The keyboard layout guide should be attached to the view"
+        )
+        XCTAssertNotNil(
+            keyboardLayout.heightConstraint,
+            "The keyboard layout guide should be configured with a height constraint"
+        )
+    }
+
+    func testKeyboardLayout_ReusesExistingGuide() {
+        let view = UIView(frame: UIScreen.main.bounds)
+
+        let firstKeyboardLayout = view.keyboardLayout
+        let secondKeyboardLayout = view.keyboardLayout
+
+        XCTAssertTrue(
+            firstKeyboardLayout === secondKeyboardLayout,
+            "The public keyboardLayout getter should reuse an existing guide"
+        )
+        XCTAssertEqual(
+            view.layoutGuides.filter { $0.identifier == "KeyboardLayoutGuide" }.count,
+            1,
+            "The view should not accumulate duplicate keyboard layout guides"
+        )
     }
 
     func testAdjustKeyboardWhenKeyboardWillShow() {
@@ -67,9 +120,17 @@ final class KeyboardLayoutGuideTests: XCTestCase {
         NotificationCenter.default.post(notification)
 
         let expectedHeight = screenHeight - keyboardFrame.minY // Should be 216
-        XCTAssertEqual(SKKeyboard.shared.currentHeight, expectedHeight, "SKKeyboard.shared.currentHeight should be properly updated with the keyboard notification")
+        XCTAssertEqual(
+            SKKeyboard.shared.currentHeight,
+            expectedHeight,
+            "SKKeyboard.shared.currentHeight should be properly updated with the keyboard notification"
+        )
 
-        XCTAssertEqual(sut.heightConstraint?.constant, expectedHeight, "The height constraint should be properly adjusted based on the keyboard height")
+        XCTAssertEqual(
+            sut.heightConstraint?.constant,
+            expectedHeight,
+            "The height constraint should be properly adjusted based on the keyboard height"
+        )
     }
 
     func testAdjustKeyboardWhenKeyboardWillHide() {
@@ -79,14 +140,52 @@ final class KeyboardLayoutGuideTests: XCTestCase {
 
         NotificationCenter.default.post(notification)
 
-        XCTAssertEqual(SKKeyboard.shared.currentHeight, 0, "SKKeyboard.shared.currentHeight should be reset to 0 when the keyboard hides")
+        XCTAssertEqual(
+            SKKeyboard.shared.currentHeight,
+            0,
+            "SKKeyboard.shared.currentHeight should be reset to 0 when the keyboard hides"
+        )
 
-        XCTAssertEqual(sut.heightConstraint?.constant, 0, "The height constraint should be reset to 0 when the keyboard hides")
+        XCTAssertEqual(
+            sut.heightConstraint?.constant,
+            0,
+            "The height constraint should be reset to 0 when the keyboard hides"
+        )
     }
 
-    func testDeinit_RemovesObservers() {
-        sut = nil
-        XCTAssertNil(NotificationCenter.default.observationInfo, "All observers should be removed on deinit")
+    func testDeinit_RemovesObserversFromInjectedNotificationCenter() {
+        let notificationCenter = NotificationCenterSpy()
+        var guide: KeyboardLayoutGuide? = KeyboardLayoutGuide(notificationCenter: notificationCenter)
+        let expectedObserverIdentifier = guide.map { ObjectIdentifier($0) }
+
+        guide = nil
+
+        XCTAssertEqual(
+            notificationCenter.removeObserverCallCount,
+            1,
+            "The guide should remove itself from its injected notification center"
+        )
+        XCTAssertEqual(
+            notificationCenter.removedObserverIdentifier,
+            expectedObserverIdentifier,
+            "The removed observer should be the deallocated guide"
+        )
+    }
+}
+
+private final class NotificationCenterSpy: NotificationCenter {
+
+    private(set) var removeObserverCallCount = 0
+    private(set) var removedObserverIdentifier: ObjectIdentifier?
+
+    override func removeObserver(_ observer: Any) {
+        removeObserverCallCount += 1
+
+        if let observer = observer as? AnyObject {
+            removedObserverIdentifier = ObjectIdentifier(observer)
+        }
+
+        super.removeObserver(observer)
     }
 }
 

--- a/Tests/SketchKitTests/KeyboardLayoutGuideTests.swift
+++ b/Tests/SketchKitTests/KeyboardLayoutGuideTests.swift
@@ -133,6 +133,33 @@ final class KeyboardLayoutGuideTests: XCTestCase {
         )
     }
 
+    func testAdjustKeyboard_UsesWindowConversion_WhenViewIsHostedInWindow() {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.addSubview(mockView)
+        sut.setUp()
+
+        let screenHeight = UIScreen.main.bounds.height
+        let keyboardFrame = CGRect(x: 0, y: screenHeight - 216, width: 320, height: 216)
+        let notification = Notification(name: UIResponder.keyboardWillChangeFrameNotification, object: nil, userInfo: [
+            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: keyboardFrame),
+            UIResponder.keyboardAnimationDurationUserInfoKey: CGFloat(0.25)
+        ])
+
+        NotificationCenter.default.post(notification)
+
+        let expectedHeight = 216 - mockView.safeAreaInsets.bottom
+        XCTAssertEqual(
+            SKKeyboard.shared.currentHeight,
+            expectedHeight,
+            "The keyboard height should be computed through the window-conversion path when the view has a window"
+        )
+        XCTAssertEqual(
+            sut.heightConstraint?.constant,
+            expectedHeight,
+            "The height constraint should reflect the window-converted keyboard intersection"
+        )
+    }
+
     func testAdjustKeyboardWhenKeyboardWillHide() {
         sut.setUp()
 


### PR DESCRIPTION
This pull request updates the keyboard layout guide logic to improve keyboard frame handling, observer management, and test coverage. The main enhancements include more accurate keyboard height calculations relative to a specific view, dependency injection for the notification center to support better testing, and expanded tests for guide creation, reuse, and observer removal.

**Keyboard frame handling improvements:**
* The `Notification.keyboardHeight` logic now calculates keyboard height relative to a specific view when provided, using a new `keyboardHeight(in:)` method for improved accuracy in multi-window and safe area scenarios. [[1]](diffhunk://#diff-36fb46f96b2e37c036e73c3b6b0919c87426a249f54f311abc50cc9685867d00L74-R89) [[2]](diffhunk://#diff-36fb46f96b2e37c036e73c3b6b0919c87426a249f54f311abc50cc9685867d00R127-R156)
* The internal animation logic was simplified by removing the notification parameter from the `animate()` method, as it is no longer needed.

**Observer management and dependency injection:**
* The `KeyboardLayoutGuide` now accepts a `NotificationCenter` instance (defaulting to `.default`) for observer registration and removal, making it more testable and flexible. Observer removal in `deinit` now uses the injected notification center. [[1]](diffhunk://#diff-36fb46f96b2e37c036e73c3b6b0919c87426a249f54f311abc50cc9685867d00R25-R28) [[2]](diffhunk://#diff-36fb46f96b2e37c036e73c3b6b0919c87426a249f54f311abc50cc9685867d00L52-R54)

**Testing improvements:**
* Unit tests were expanded to verify guide creation, reuse, and observer removal. A `NotificationCenterSpy` was introduced to test that observers are properly removed from the injected notification center. [[1]](diffhunk://#diff-232250daba2517c18545c357c2e5a9c584631da66300a88552a626527c8cded0L49-R103) [[2]](diffhunk://#diff-232250daba2517c18545c357c2e5a9c584631da66300a88552a626527c8cded0L82-R188)
* Test assertions were refactored for clarity, and test view setup now uses a frame matching the screen bounds for more realistic layout behavior. [[1]](diffhunk://#diff-232250daba2517c18545c357c2e5a9c584631da66300a88552a626527c8cded0L20-R20) [[2]](diffhunk://#diff-232250daba2517c18545c357c2e5a9c584631da66300a88552a626527c8cded0L38-R42) [[3]](diffhunk://#diff-232250daba2517c18545c357c2e5a9c584631da66300a88552a626527c8cded0L70-R133)

**Dependency updates:**
* The Codecov GitHub Action was updated from v6.0.1 to v7.0.0 in the CI workflow.